### PR TITLE
docs: add multilingual documentation navigation links

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -3,6 +3,9 @@
 pnpm ワークスペースカタログ依存関係をチェックおよび更新するための強力な CLI ツール。
 [npm-check-updates](https://github.com/raineorshine/npm-check-updates)にインスパイアされました。
 
+**📖 ドキュメント言語**: [English](README.md) | [中文](README.zh-CN.md) |
+[日本語](README.ja.md)
+
 [![CI](https://img.shields.io/github/actions/workflow/status/houko/pnpm-catalog-updates/ci.yml?label=CI&logo=github)](https://github.com/houko/pnpm-catalog-updates/actions)
 [![npm](https://img.shields.io/npm/v/pnpm-catalog-updates)](https://www.npmjs.com/package/pnpm-catalog-updates)
 [![Coverage](https://img.shields.io/coveralls/github/houko/pnpm-catalog-updates/main)](https://coveralls.io/github/houko/pnpm-catalog-updates)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ A powerful CLI tool to check and update pnpm workspace catalog dependencies,
 inspired by
 [npm-check-updates](https://github.com/raineorshine/npm-check-updates).
 
+**📖 Documentation Languages**: [English](README.md) | [中文](README.zh-CN.md) |
+[日本語](README.ja.md)
+
 [![CI](https://img.shields.io/github/actions/workflow/status/houko/pnpm-catalog-updates/ci.yml?label=CI&logo=github)](https://github.com/houko/pnpm-catalog-updates/actions)
 [![npm](https://img.shields.io/npm/v/pnpm-catalog-updates)](https://www.npmjs.com/package/pnpm-catalog-updates)
 [![Coverage](https://img.shields.io/coveralls/github/houko/pnpm-catalog-updates/main)](https://coveralls.io/github/houko/pnpm-catalog-updates)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,6 +3,9 @@
 一个强大的 CLI 工具，用于检查和更新 pnpm 工作区目录依赖，灵感来自
 [npm-check-updates](https://github.com/raineorshine/npm-check-updates)。
 
+**📖 文档语言**: [English](README.md) | [中文](README.zh-CN.md) |
+[日本語](README.ja.md)
+
 [![CI](https://img.shields.io/github/actions/workflow/status/houko/pnpm-catalog-updates/ci.yml?label=CI&logo=github)](https://github.com/houko/pnpm-catalog-updates/actions)
 [![npm](https://img.shields.io/npm/v/pnpm-catalog-updates)](https://www.npmjs.com/package/pnpm-catalog-updates)
 [![Coverage](https://img.shields.io/coveralls/github/houko/pnpm-catalog-updates/main)](https://coveralls.io/github/houko/pnpm-catalog-updates)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-catalog-updates",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary

This PR adds multilingual navigation links to all README files, improving accessibility for international users.

### 📖 Changes Made

#### Navigation Links Added
Added language navigation section to the top of all README files:
- **English**: `README.md` 
- **中文**: `README.zh-CN.md`
- **日本語**: `README.ja.md`

#### Files Updated
- ✅ `README.md` - Added multilingual navigation in English
- ✅ `README.zh-CN.md` - Added multilingual navigation in Chinese  
- ✅ `README.ja.md` - Added multilingual navigation in Japanese

### 🌐 User Experience Improvements

1. **Easy Language Switching**: Users can quickly switch between documentation languages
2. **Better Accessibility**: Clear indication of available translations
3. **Professional Appearance**: Consistent navigation across all language versions
4. **International User Support**: Makes the project more welcoming to global users

### 📋 Implementation Details

The navigation links are placed prominently at the top of each README file, just after the title and description, using the format:

```markdown
**📖 Documentation Languages**: [English](README.md) | [中文](README.zh-CN.md) | [日本語](README.ja.md)
```

This provides:
- 📖 Clear visual indicator with book emoji
- 🔗 Direct links to each language version
- 🌍 Consistent placement across all files
- ✨ Professional appearance

### 🔍 Visual Example

Before:
```
# pnpm-catalog-updates

A powerful CLI tool...
```

After:
```
# pnpm-catalog-updates

A powerful CLI tool...

**📖 Documentation Languages**: [English](README.md) | [中文](README.zh-CN.md) | [日本語](README.ja.md)
```

## Test plan

- [ ] Verify all language links work correctly
- [ ] Check that navigation appears consistently across all README files
- [ ] Confirm the formatting looks good on GitHub
- [ ] Test that links work from any language version

This small but important improvement makes the project more accessible to users worldwide\! 🌏

🤖 Generated with [Claude Code](https://claude.ai/code)